### PR TITLE
Improve the contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,16 @@
 
 Please read through [our current open issues](https://github.com/DevLifts/devlifts-api/projects) for the current release and see if there's anything you'd like to work on! Also, please check out [this project's roadmap](https://spectrum.chat/thread/091f1474-2c85-4403-ba38-4e20c766ef3b) to ensure you don't do any work that's not in line with where we're trying to go.
 
+## Claiming an Issue
+
+If you're working on an open issue, please take a moment to comment on the issue to let everyone know that you're working on it. This helps prevent multiple contributors from working on the same issue. If for some reason you can't complete the work, leave a comment letting everyone know the issue is up for grabs again.
+
+Generally, you should always have a related issue with discussions for your work. Open an issue if you can't find one related to what you want to work on.
+
 ## Submitting a Pull Request
 
 Good pull requests, such as patches, improvements, and new features, are a fantastic help. They should remain focused in scope and avoid containing unrelated commits.
 
-Please ask first if somebody else is already working on this or the core developers think your feature is in-scope for this project. Generally always have a related issue with discussions for whatever you are including. Open an issue if you can't find one related to what you want to work on.
+Please make an effort to write [good commit messages](https://chris.beams.io/posts/git-commit/).
+
+By submitting patches, you agree to allow the project owners to license your work under the terms of the [MIT License](https://github.com/DevLifts/devlifts-api/blob/master/LICENSE).


### PR DESCRIPTION
I added a section documenting the process of claiming an issue and
made an organization change.

I also added a link to a well known blog post about writing good commit 
messages.

Refs #8